### PR TITLE
Fix default color on dark theme

### DIFF
--- a/themes/github-sharp-dark-theme.color-theme.json
+++ b/themes/github-sharp-dark-theme.color-theme.json
@@ -100,7 +100,7 @@
         "markup.fenced_code meta.embedded.block"
       ],
       "settings": {
-        "foreground": "#24292eff"
+        "foreground": "#c3c6c9"
       }
     },
     {


### PR DESCRIPTION
The default color on the dark theme is broken; this fixes it! Here's an example of some JavaScript and some SQL code: 

Before:
<img width="594" alt="Screen Shot 2020-03-20 at 15 00 43" src="https://user-images.githubusercontent.com/6351754/77197490-a6e9f300-6abb-11ea-8779-62ee564cee65.png">

After:
<img width="602" alt="Screen Shot 2020-03-20 at 15 00 22" src="https://user-images.githubusercontent.com/6351754/77197508-aea99780-6abb-11ea-8cc2-53cc56b54c44.png">

Fixes issue https://github.com/thenikso/github-plus-theme/issues/15 which was placed on the wrong repo. For anyone who wants to fix this locally, you can add the following to your vscode settings json file:

```json
{
 "editor.tokenColorCustomizations": {
    "[GitHub Sharp Dark]": {
      "textMateRules": [
        {
          "scope": [
            "keyword.operator.accessor",
            "meta.group.braces.round.function.arguments",
            "meta.template.expression",
            "markup.fenced_code meta.embedded.block"
          ],
          "settings": {
            "foreground": "#c3c6c9"
          }
        },
      ]
    },
  }
}
```